### PR TITLE
Allow changing the annotation used

### DIFF
--- a/encoder.go
+++ b/encoder.go
@@ -16,6 +16,13 @@ func NewEncoder() *Encoder {
 	return &Encoder{TagID: "url"}
 }
 
+// SetAliasTag changes the tag used to locate urlvalues annotations. The default
+// value is "url"
+func (e *Encoder) SetAliasTag(tag string) *Encoder {
+	e.TagID = tag
+	return e
+}
+
 // Encode encodes a struct into map[string][]string.
 //
 // Intended for use with url.Values.

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -3,23 +3,23 @@ package urlvalues
 import "testing"
 
 type S1 struct {
-	F01 int     `url:"f01"`
-	F02 int     `url:"-"`
-	F03 string  `url:"f03"`
-	F04 string  `url:"f04,omitempty"`
-	F05 bool    `url:"f05"`
-	F06 bool    `url:"f06"`
-	F07 *string `url:"f07"`
-	F08 *int8   `url:"f08"`
-	F09 float64 `url:"f09"`
+	F01 int     `url:"f01" alttag:"t01"`
+	F02 int     `url:"-" alttag:"-"`
+	F03 string  `url:"f03" alttag:"t03"`
+	F04 string  `url:"f04,omitempty" alttag:"t04,omitempty"`
+	F05 bool    `url:"f05" alttag:"t05"`
+	F06 bool    `url:"f06" alttag:"t06"`
+	F07 *string `url:"f07" alttag:"t07"`
+	F08 *int8   `url:"f08" alttag:"t08"`
+	F09 float64 `url:"f09" alttag:"t09"`
 	F10 S2
 }
 
 type S2 struct {
-	F01 int `url:"f201"`
+	F01 int `url:"f201" alttag:"t201"`
 }
 
-func TestFilled(t *testing.T) {
+func testFilled(t *testing.T, useAltTag bool) {
 	f07 := "seven"
 	var f08 int8 = 8
 	s2 := S2{10}
@@ -37,20 +37,35 @@ func TestFilled(t *testing.T) {
 	}
 
 	vals := make(map[string][]string)
-	_ = NewEncoder().Encode(s, vals)
+	encoder := NewEncoder()
+	tagPrefix := "f"
 
-	valExists(t, "f01", "1", vals)
-	valNotExists(t, "f02", vals)
-	valExists(t, "f03", "three", vals)
-	valExists(t, "f05", "1", vals)
-	valExists(t, "f06", "0", vals)
-	valExists(t, "f07", "seven", vals)
-	valExists(t, "f08", "8", vals)
-	valExists(t, "f09", "1.618000", vals)
-	valExists(t, "f201", "10", vals)
+	if useAltTag {
+		encoder.SetAliasTag("alttag")
+		tagPrefix = "t"
+	}
+	_ = encoder.Encode(s, vals)
+
+	valExists(t, tagPrefix+"01", "1", vals)
+	valNotExists(t, tagPrefix+"02", vals)
+	valExists(t, tagPrefix+"03", "three", vals)
+	valExists(t, tagPrefix+"05", "1", vals)
+	valExists(t, tagPrefix+"06", "0", vals)
+	valExists(t, tagPrefix+"07", "seven", vals)
+	valExists(t, tagPrefix+"08", "8", vals)
+	valExists(t, tagPrefix+"09", "1.618000", vals)
+	valExists(t, tagPrefix+"201", "10", vals)
 }
 
-func TestEmpty(t *testing.T) {
+func TestFilledWithDefaultTag(t *testing.T) {
+	testFilled(t, false)
+}
+
+func TestFilledWithCustomTag(t *testing.T) {
+	testFilled(t, true)
+}
+
+func testEmpty(t *testing.T, useAltTag bool) {
 	s := &S1{
 		F01: 1,
 		F02: 2,
@@ -58,10 +73,25 @@ func TestEmpty(t *testing.T) {
 	}
 
 	vals := make(map[string][]string)
-	_ = NewEncoder().Encode(s, vals)
+	encoder := NewEncoder()
+	tagPrefix := "f"
 
-	valExists(t, "f03", "three", vals)
-	valNotExists(t, "f04", vals)
+	if useAltTag {
+		encoder.SetAliasTag("alttag")
+		tagPrefix = "t"
+	}
+	_ = encoder.Encode(s, vals)
+
+	valExists(t, tagPrefix+"03", "three", vals)
+	valNotExists(t, tagPrefix+"04", vals)
+}
+
+func TestEmptyWithDefaultTag(t *testing.T) {
+	testEmpty(t, false)
+}
+
+func TestEmptyWithCustomTag(t *testing.T) {
+	testEmpty(t, true)
 }
 
 func valExists(t *testing.T, key string, expect string, result map[string][]string) {


### PR DESCRIPTION
Adds SetAliasTag to mirror behavior of schema allowing the same annotations to be reused between the two libraries.

Updates tests to verify equivalent functionality on both tags.
